### PR TITLE
Add Python order fulfillment Temporal sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# Python Order Fulfilment Sample
+
+This project demonstrates a Temporal application that fulfils an order using
+three activities executed in sequence:
+
+1. `process_payment`
+2. `reserve_inventory`
+3. `deliver_order`
+
+The workflow waits for a human approval signal before delivery. If approval is
+not received within 30 seconds the order expires.
+
+## Files
+
+All application code lives in `order_application/`:
+
+- `shared.py` – dataclasses for the order information
+- `activities.py` – implementations of `process_payment`,
+  `reserve_inventory`, and `deliver_order`
+- `workflow.py` – `OrderWorkflow` definition with an `approve_order` signal
+- `worker.py` – long‑running worker process
+- `starter.py` – starts an `OrderWorkflow` execution
+- `approve.py` – sends the `approve_order` signal to a workflow
+
+## Running the sample
+
+1. **Start the Temporal development server** (if not already running):
+   ```bash
+   temporal server start-dev &
+   ```
+2. **Start the worker**:
+   ```bash
+   cd order_application
+   ./worker.py &
+   ```
+3. **Start a workflow**:
+   ```bash
+   ./starter.py 12/30
+   ```
+   The command prints the workflow ID. The workflow now waits for approval.
+4. **Approve the order**:
+   ```bash
+   ./approve.py <workflow-id>
+   ```
+   The workflow completes after the approval signal is received.
+5. **Cleanup** – stop the worker process when finished.
+
+## Scenarios
+
+- **Happy path** – run the commands above and approve the order.
+- **API downtime** – uncomment the request in `reserve_inventory` to simulate a
+  failing external service.
+- **Invalid order** – start the workflow with an expired card:
+  `./starter.py 12/23`. The `process_payment` activity fails.
+- **Human in the loop** – start the workflow and send the approval signal from
+  `approve.py`.
+- **Approve or expire** – if no approval is sent within 30 seconds the workflow
+  raises `Order approval timed out`.
+- **Bug in workflow** – add `raise RuntimeError("workflow bug!")` inside
+  `OrderWorkflow.run` to see workflow failure handling.
+
+## Notes
+
+All scripts use [uv](https://github.com/astral-sh/uv) shebangs to manage
+runtime dependencies automatically.

--- a/order_application/activities.py
+++ b/order_application/activities.py
@@ -1,0 +1,33 @@
+import asyncio
+from datetime import datetime
+from temporalio import activity
+from shared import Order
+
+
+@activity.defn
+async def process_payment(order: Order) -> str:
+    """Charge the customer's credit card."""
+    await asyncio.sleep(1)
+    month, year = order.credit_card_expiry.split("/")
+    exp_year = int("20" + year)
+    exp_month = int(month)
+    now = datetime.utcnow()
+    if exp_year < now.year or (exp_year == now.year and exp_month < now.month):
+        raise activity.ApplicationError("Credit card expired")
+    return f"Payment processed for order {order.id}"
+
+
+@activity.defn
+async def reserve_inventory(order: Order) -> str:
+    """Reserve items for the order."""
+    await asyncio.sleep(1)
+    # Simulated external API call; uncomment to simulate downtime
+    # import requests; requests.get("http://localhost:9999/reserve", timeout=1).raise_for_status()
+    return f"Inventory reserved for order {order.id}"
+
+
+@activity.defn
+async def deliver_order(order: Order) -> str:
+    """Deliver the order to the customer."""
+    await asyncio.sleep(1)
+    return f"Order {order.id} delivered"

--- a/order_application/approve.py
+++ b/order_application/approve.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["temporalio>=1.3.0"]
+# ///
+
+import asyncio
+import sys
+from temporalio.client import Client
+from workflow import OrderWorkflow
+
+
+async def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: approve.py <workflow-id>")
+        sys.exit(1)
+    workflow_id = sys.argv[1]
+    client = await Client.connect("localhost:7233")
+    handle = client.get_workflow_handle(workflow_id)
+    await handle.signal(OrderWorkflow.approve_order)
+    print(f"Sent approval signal to {workflow_id}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/order_application/shared.py
+++ b/order_application/shared.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Order:
+    """Order information passed between activities."""
+
+    id: str
+    item: str
+    quantity: int
+    credit_card_number: str
+    credit_card_expiry: str  # format MM/YY

--- a/order_application/starter.py
+++ b/order_application/starter.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["temporalio>=1.3.0"]
+# ///
+
+import asyncio
+import logging
+import sys
+import uuid
+from temporalio.client import Client
+from shared import Order
+from workflow import OrderWorkflow
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    expiry = sys.argv[1] if len(sys.argv) > 1 else "12/30"
+    order = Order(
+        id=str(uuid.uuid4()),
+        item="Widget",
+        quantity=1,
+        credit_card_number="4111111111111111",
+        credit_card_expiry=expiry,
+    )
+
+    client = await Client.connect("localhost:7233")
+    handle = await client.start_workflow(
+        OrderWorkflow.run,
+        order,
+        id=f"order-workflow-{order.id}",
+        task_queue="order-task-queue",
+    )
+    logger.info(f"Started workflow {handle.id}")
+    print(handle.id)
+
+    if "--approve" in sys.argv:
+        await handle.signal(OrderWorkflow.approve_order)
+        result = await handle.result()
+        print(f"Result: {result}")
+        logger.info("Workflow completed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/order_application/worker.py
+++ b/order_application/worker.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["temporalio>=1.3.0"]
+# ///
+
+import asyncio
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+from temporalio.client import Client
+from temporalio.worker import Worker
+from activities import process_payment, reserve_inventory, deliver_order
+from workflow import OrderWorkflow
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+
+    pid = os.getpid()
+    with open("worker.pid", "w") as f:
+        f.write(str(pid))
+    logger.info(f"Worker starting with PID: {pid}")
+
+    client = await Client.connect("localhost:7233")
+    logger.info("Connected to Temporal server at localhost:7233")
+
+    async with Worker(
+        client,
+        task_queue="order-task-queue",
+        workflows=[OrderWorkflow],
+        activities=[process_payment, reserve_inventory, deliver_order],
+        activity_executor=ThreadPoolExecutor(),
+    ):
+        logger.info("Worker started and polling for tasks on queue: order-task-queue")
+        logger.info("Worker ready")
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/order_application/workflow.py
+++ b/order_application/workflow.py
@@ -1,0 +1,45 @@
+import asyncio
+from datetime import timedelta
+from temporalio import workflow
+from temporalio.exceptions import ApplicationError
+from shared import Order
+from activities import process_payment, reserve_inventory, deliver_order
+
+
+@workflow.defn
+class OrderWorkflow:
+    """Workflow coordinating order fulfilment."""
+
+    def __init__(self) -> None:
+        self._approved = False
+
+    @workflow.signal
+    async def approve_order(self) -> None:
+        """Signal to approve the order."""
+        self._approved = True
+
+    @workflow.run
+    async def run(self, order: Order) -> str:
+        await workflow.execute_activity(
+            process_payment,
+            order,
+            schedule_to_close_timeout=timedelta(seconds=10),
+        )
+
+        await workflow.execute_activity(
+            reserve_inventory,
+            order,
+            schedule_to_close_timeout=timedelta(seconds=10),
+        )
+
+        try:
+            await workflow.wait_condition(lambda: self._approved, timeout=timedelta(seconds=30))
+        except asyncio.TimeoutError:
+            raise ApplicationError("Order approval timed out")
+
+        result = await workflow.execute_activity(
+            deliver_order,
+            order,
+            schedule_to_close_timeout=timedelta(seconds=10),
+        )
+        return result


### PR DESCRIPTION
## Summary
- implement order fulfillment workflow with sequential activities and approval signal
- provide worker, starter, and signal helper scripts using uv shebangs
- document scenarios (happy path, downtime, invalid order, approval, expiration, workflow bug)

## Testing
- `python -m py_compile order_application/*.py`
- `temporal --version`
- `./worker.py` then `./starter.py 12/30 --approve`


------
https://chatgpt.com/codex/tasks/task_b_68bb0bda43fc83288bf3cb1dcc1b8dad